### PR TITLE
feat: gmi and asset value engine

### DIFF
--- a/engine/asset.js
+++ b/engine/asset.js
@@ -1,0 +1,101 @@
+/**
+ * Asset value update engine.
+ *
+ * rollValueUpdate(asset, dice, gmiDelta, playerId, round)
+ *   → { newValue, delta, roll, buzzRoll, baseDelta, gmiAdjustment, logEvent }
+ *
+ * Looks up the d6 result in asset.baseValueUpdateRule.outcomes for the base
+ * delta, then applies GMI via applyGMIToAsset. All intermediate rolls are
+ * recorded for the replay log.
+ */
+
+import { applyGMIToAsset } from './gmi.js';
+
+/**
+ * Finds the outcome delta for a given d6 roll by scanning the asset's
+ * baseValueUpdateRule.outcomes array (range-based lookup).
+ *
+ * @param {Array<{range: [number,number], delta: number}>} outcomes
+ * @param {number} roll  1-6
+ * @returns {number}  delta for that roll
+ */
+function lookupOutcome(outcomes, roll) {
+  for (const { range, delta } of outcomes) {
+    if (roll >= range[0] && roll <= range[1]) return delta;
+  }
+  throw new Error(`No outcome found for roll ${roll} in outcome table`);
+}
+
+/**
+ * Resolves one year's value update for a single asset.
+ *
+ * Steps:
+ *  1. Roll d6 → look up base delta in asset.baseValueUpdateRule.outcomes
+ *  2. Apply base delta to current value (floor 1) → intermediate value
+ *  3. Apply industry-specific GMI mechanic via applyGMIToAsset (may roll
+ *     additional dice for FINANCE / MEDIA_ENTERTAINMENT)
+ *  4. Build a log event capturing every intermediate value for replay
+ *
+ * The asset object is not mutated; the caller is responsible for writing
+ * newValue back to game state.
+ *
+ * @param {object} asset      — card object with currentValue (or baseValue),
+ *                              industry, tier, baseValueUpdateRule, companyName
+ * @param {import('./dice.js').Dice} dice
+ * @param {number} gmiDelta   — integer from computeGMIDelta for this round
+ * @param {string|null} [playerId]  — for the log event
+ * @param {number|null} [round]     — for the log event
+ * @returns {{
+ *   newValue:      number,
+ *   delta:         number,   // total change from oldValue
+ *   roll:          number,   // d6 used for outcome table lookup
+ *   buzzRoll:      number|null,
+ *   baseDelta:     number,
+ *   gmiAdjustment: number,
+ *   logEvent:      object,
+ * }}
+ */
+export function rollValueUpdate(asset, dice, gmiDelta, playerId = null, round = null) {
+  const oldValue = asset.currentValue ?? asset.baseValue;
+
+  // ── Step 1: base value update roll ───────────────────────────────────────
+  const roll = dice.d6();
+  const baseDelta = lookupOutcome(asset.baseValueUpdateRule.outcomes, roll);
+
+  // ── Step 2: apply base delta (floor at 1) ────────────────────────────────
+  const valueAfterBase = Math.max(1, oldValue + baseDelta);
+
+  // ── Step 3: apply GMI via industry mechanic ──────────────────────────────
+  // Pass a shallow copy with the post-base-delta value so applyGMIToAsset
+  // operates from the correct intermediate value.
+  const assetAtIntermediate = { ...asset, currentValue: valueAfterBase };
+  const { newValue, gmiAdjustment, buzzRoll } = applyGMIToAsset(
+    assetAtIntermediate,
+    gmiDelta,
+    dice,
+  );
+
+  // ── Step 4: log event ────────────────────────────────────────────────────
+  const logEvent = {
+    type:          'ASSET_VALUE_UPDATE',
+    assetId:       asset.companyName,
+    playerId,
+    round,
+    roll,
+    buzzRoll,
+    baseDelta,
+    gmiAdjustment,
+    newValue,
+    oldValue,
+  };
+
+  return {
+    newValue,
+    delta:  newValue - oldValue,
+    roll,
+    buzzRoll,
+    baseDelta,
+    gmiAdjustment,
+    logEvent,
+  };
+}

--- a/engine/gmi.js
+++ b/engine/gmi.js
@@ -1,0 +1,129 @@
+/**
+ * GMI (Global Market Index) computation and per-asset application.
+ *
+ * computeGMIDelta  — resolves this year's integer GMI delta from a global event card
+ * applyGMIToAsset  — applies that delta to an asset using its industry mechanics
+ */
+
+/**
+ * Modifier table used by BULL_RUN, FLAT, and WILDCARD cards.
+ * d6 roll → adjustment to add to gmiBase.
+ */
+function rollModifier(roll) {
+  if (roll <= 2) return -1;
+  if (roll <= 4) return  0;
+  return +1;
+}
+
+/**
+ * Categories whose gmiBase is augmented by a d6 roll using rollModifier().
+ * All other categories use gmiBase directly (gmiDieRoll is null on the card).
+ */
+const ROLL_MODIFIER_CATEGORIES = new Set(['BULL_RUN', 'FLAT', 'WILDCARD']);
+
+/**
+ * Computes the integer GMI delta for the current year.
+ *
+ * @param {object} globalEventCard  — a card from global-event-cards.json
+ * @param {import('./dice.js').Dice} dice
+ * @returns {number}  integer delta (may be negative)
+ */
+export function computeGMIDelta(globalEventCard, dice) {
+  const base = globalEventCard.gmiBase;
+
+  // Use the category set first; fall back to the card's own gmiDieRoll field
+  // so future card additions are handled automatically.
+  const needsRoll =
+    ROLL_MODIFIER_CATEGORIES.has(globalEventCard.eventCategory) ||
+    globalEventCard.gmiDieRoll === 'd6';
+
+  if (needsRoll) {
+    return base + rollModifier(dice.d6());
+  }
+
+  return base;
+}
+
+/**
+ * Applies a pre-computed gmiDelta to an asset using its industry's mechanics.
+ *
+ * Industry rules
+ * ──────────────
+ * ENERGY            apply gmiDelta twice (T1/T2) or three times (T3)
+ * MANUFACTURING     apply Math.trunc(gmiDelta / 2)  — halved toward zero
+ * FINANCE           apply once; if gmiDelta < 0, roll d6 — on 1-3 apply a second time
+ * MEDIA_ENTERTAINMENT  roll buzz die: 1-2 → take the lower of (×1, ×2); 3-6 → take higher
+ * TECHNOLOGY        apply normally (note: does NOT affect loan capacity — enforced elsewhere)
+ * REAL_ESTATE       apply normally
+ *
+ * The asset value floor is always 1.
+ *
+ * @param {object} asset       — must have currentValue (or baseValue), industry, tier
+ * @param {number} gmiDelta    — integer delta from computeGMIDelta
+ * @param {import('./dice.js').Dice} dice  — needed for FINANCE and MEDIA rolls
+ * @returns {{ newValue: number, gmiAdjustment: number, buzzRoll: number|null }}
+ */
+export function applyGMIToAsset(asset, gmiDelta, dice) {
+  const currentValue = asset.currentValue ?? asset.baseValue;
+  const industry     = asset.industry;
+  const tier         = asset.tier ?? 1;
+
+  let gmiAdjustment;
+  let buzzRoll = null;
+
+  switch (industry) {
+    case 'ENERGY': {
+      // T1 and T2 apply twice; T3 applies three times (upstream amplification)
+      const multiplier = tier === 3 ? 3 : 2;
+      gmiAdjustment = gmiDelta * multiplier;
+      break;
+    }
+
+    case 'MANUFACTURING': {
+      // GMI-resistant: halved, rounded toward zero
+      gmiAdjustment = Math.trunc(gmiDelta / 2);
+      break;
+    }
+
+    case 'FINANCE': {
+      // Normal application; on a downturn, chance of double impact
+      gmiAdjustment = gmiDelta;
+      if (gmiDelta < 0) {
+        const roll = dice.d6();
+        if (roll <= 3) {
+          gmiAdjustment += gmiDelta;   // second application
+        }
+      }
+      break;
+    }
+
+    case 'MEDIA_ENTERTAINMENT': {
+      // Buzz die mechanic:
+      // Roll buzz die (d6): 1-2 = bad buzz → take lower of (×1, ×2);
+      //                     3-6 = good buzz → take higher of (×1, ×2)
+      //
+      // "Lower" of the two candidate adjustments means worse outcome:
+      //   positive gmiDelta → ×1 is lower (less gain)
+      //   negative gmiDelta → ×2 is lower (more loss)
+      // "Higher" is the better outcome in each direction.
+      buzzRoll = dice.d6();
+      const single = gmiDelta;
+      const doubled = gmiDelta * 2;
+      gmiAdjustment = buzzRoll <= 2
+        ? Math.min(single, doubled)    // bad buzz
+        : Math.max(single, doubled);   // good buzz
+      break;
+    }
+
+    case 'TECHNOLOGY':
+    case 'REAL_ESTATE':
+    default:
+      // Normal application. For TECHNOLOGY, loan-capacity immunity is
+      // enforced at the settlement layer, not here.
+      gmiAdjustment = gmiDelta;
+      break;
+  }
+
+  const newValue = Math.max(1, currentValue + gmiAdjustment);
+  return { newValue, gmiAdjustment, buzzRoll };
+}


### PR DESCRIPTION
engine/gmi.js
- computeGMIDelta(globalEventCard, dice): resolves integer GMI delta BULL_RUN/FLAT/WILDCARD roll d6 and apply modifier table (1-2→-1, 3-4→0, 5-6→+1) all other categories use gmiBase directly; falls back to card.gmiDieRoll field
- applyGMIToAsset(asset, gmiDelta, dice): industry-specific GMI mechanics ENERGY: ×2 (T1/T2) or ×3 (T3) MANUFACTURING: Math.trunc(gmiDelta/2) FINANCE: +gmiDelta again on d6 1-3 when delta < 0 MEDIA_ENTERTAINMENT: buzz die — bad buzz (1-2) takes lower of ×1/×2, good buzz (3-6) takes higher TECHNOLOGY/REAL_ESTATE: apply normally floor always 1

engine/asset.js
- rollValueUpdate(asset, dice, gmiDelta, playerId, round): rolls d6 for base delta via outcome table lookup, applies GMI via applyGMIToAsset, returns { newValue, delta, roll, buzzRoll, baseDelta, gmiAdjustment, logEvent } logEvent.type = 'ASSET_VALUE_UPDATE' with full replay audit trail