### PR TITLE
feat: market events ceo integration

### DIFF
--- a/engine/ceo.js
+++ b/engine/ceo.js
@@ -1,0 +1,299 @@
+/**
+ * CEO ability dispatch and explicit per-ability activators.
+ *
+ * applyCEOAbilities(player, phase, state, dice, context)
+ *   → { logEvents }
+ *   Auto-resolves passive / auto-trigger abilities for the given phase.
+ *   Phases: 'LABOR' | 'AUCTION' | 'VALUE_UPDATE' | 'SETTLEMENT'
+ *
+ * useSuitMarketRefresh(player, state)
+ *   → { logEvent }   (ONCE_PER_GAME; returns null logEvent if already used)
+ *
+ * useGamblerReroll(player, originalRoll, dice)
+ *   → { newRoll, oldRoll, stressGained, logEvent }
+ *
+ * useLobbyistGMIAdjust(player, state, direction)
+ *   → { logEvent }   direction: +1 | -1
+ *
+ * resetCEOYearlyAbilities(player)
+ *   → void   (clears ONCE_PER_YEAR flags at year end)
+ *
+ * Ability state is tracked on player.ceoAbilityState (lazily initialised):
+ *   { suitRefreshUsed: boolean, gamblerRerollUsedThisYear: boolean,
+ *     lobbyistAdjustUsedThisYear: boolean, ... }
+ */
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Internal helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Returns (and lazily initialises) the CEO ability state object.
+ * @private
+ */
+function abilityState(player) {
+  player.ceoAbilityState = player.ceoAbilityState ?? {};
+  return player.ceoAbilityState;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Phase dispatch
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Auto-resolves passive and auto-triggered CEO abilities for the given phase.
+ *
+ * Abilities handled here (automatically, no player choice required):
+ *
+ *   LABOR phase
+ *     The Worker  — roll d6; on 4–6, gain +$1 cash (bonus income on top of base $1).
+ *     The Suit    — $3 base income every year (gross income component; caller handles
+ *                   taxable income by reading player.ceo.annualIncome = 3).
+ *                   No mutation here — annualIncome is read by computeTaxableIncome.
+ *
+ *   VALUE_UPDATE phase
+ *     The Short Seller — if gmiDelta < 0 this year, gain $1 cash (context.gmiDelta).
+ *     The Influencer   — whenever player stress increases, their highest-value
+ *                        MEDIA_ENTERTAINMENT asset gains +1. This is reactive and
+ *                        must be called by the caller after any stress increase.
+ *                        Pass context.stressDelta > 0 to trigger it here.
+ *     The Visionary    — RISK: if total asset value did not increase vs. start of
+ *                        year, gain +1 stress. Pass context.assetValueIncreased
+ *                        (boolean) to resolve this.
+ *
+ *   SETTLEMENT phase
+ *     The Tax Attorney — first $2 of income is tax-free.  No mutation here — the
+ *                        caller adjusts computeTaxableIncome inputs (or passes a
+ *                        custom free threshold) when ceoName === 'The Tax Attorney'.
+ *
+ * Abilities NOT handled here (explicit activators below):
+ *   The Suit        → useSuitMarketRefresh
+ *   The Gambler     → useGamblerReroll
+ *   The Lobbyist    → useLobbyistGMIAdjust
+ *
+ * @param {object} player
+ * @param {'LABOR'|'AUCTION'|'VALUE_UPDATE'|'SETTLEMENT'} phase
+ * @param {object} state
+ * @param {import('./dice.js').Dice} dice
+ * @param {{
+ *   gmiDelta?: number,
+ *   stressDelta?: number,
+ *   assetValueIncreased?: boolean,
+ * }} [context={}]
+ * @returns {{ logEvents: object[] }}
+ */
+export function applyCEOAbilities(player, phase, state, dice, context = {}) {
+  if (!player.alive || !player.ceo) return { logEvents: [] };
+
+  const ceoName   = player.ceo.ceoName;
+  const logEvents = [];
+
+  // ── LABOR ─────────────────────────────────────────────────────────────────
+  if (phase === 'LABOR') {
+    if (ceoName === 'The Worker') {
+      const roll = dice.d6();
+      if (roll >= 4) {
+        player.cash += 1;
+        logEvents.push({
+          type:     'CEO_ABILITY',
+          ceoName,
+          ability:  'WORKER_BONUS_INCOME',
+          roll,
+          delta:    1,
+          newCash:  player.cash,
+        });
+      } else {
+        logEvents.push({
+          type:     'CEO_ABILITY',
+          ceoName,
+          ability:  'WORKER_BONUS_INCOME',
+          roll,
+          delta:    0,
+          newCash:  player.cash,
+        });
+      }
+    }
+  }
+
+  // ── VALUE_UPDATE ──────────────────────────────────────────────────────────
+  if (phase === 'VALUE_UPDATE') {
+    // Short Seller passive: negative GMI → +$1
+    if (ceoName === 'The Short Seller' && (context.gmiDelta ?? 0) < 0) {
+      player.cash += 1;
+      logEvents.push({
+        type:     'CEO_ABILITY',
+        ceoName,
+        ability:  'SHORT_SELLER_NEGATIVE_GMI',
+        delta:    1,
+        newCash:  player.cash,
+      });
+    }
+
+    // Influencer passive: stress increase → highest MEDIA_ENTERTAINMENT asset +1
+    if (ceoName === 'The Influencer' && (context.stressDelta ?? 0) > 0) {
+      const mediaAssets = (player.assets ?? []).filter(
+        a => a.industry === 'MEDIA_ENTERTAINMENT',
+      );
+      if (mediaAssets.length > 0) {
+        // Highest-value asset
+        const target = mediaAssets.reduce((best, a) => {
+          const v = a.currentValue ?? a.baseValue;
+          return v > (best.currentValue ?? best.baseValue) ? a : best;
+        });
+        const oldValue      = target.currentValue ?? target.baseValue;
+        target.currentValue = oldValue + 1;
+        logEvents.push({
+          type:     'CEO_ABILITY',
+          ceoName,
+          ability:  'INFLUENCER_STRESS_CONTENT',
+          assetId:  target.companyName,
+          oldValue,
+          newValue: target.currentValue,
+        });
+      }
+    }
+
+    // Visionary RISK: if asset value did not increase, +1 stress
+    if (ceoName === 'The Visionary' && context.assetValueIncreased === false) {
+      player.stress += 1;
+      logEvents.push({
+        type:      'CEO_ABILITY',
+        ceoName,
+        ability:   'VISIONARY_STAGNATION_STRESS',
+        delta:     1,
+        newStress: player.stress,
+      });
+    }
+  }
+
+  return { logEvents };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Explicit activators (player-choice abilities)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * The Suit — ONCE_PER_GAME market refresh.
+ * Before the auction phase begins, discard all 4 current market cards and
+ * replace them with 4 new draws from the remaining deck.
+ * Mutates state.marketCards and state.discardPiles.marketDeck.
+ * Returns { logEvent: null } if already used this game.
+ *
+ * @param {object} player
+ * @param {object} state   — GameState
+ * @returns {{ logEvent: object|null }}
+ */
+export function useSuitMarketRefresh(player, state) {
+  if (player.ceo?.ceoName !== 'The Suit') return { logEvent: null };
+
+  const as = abilityState(player);
+  if (as.suitRefreshUsed) return { logEvent: null };
+
+  as.suitRefreshUsed = true;
+
+  const deck         = state.discardPiles.marketDeck ?? [];
+  const discarded    = state.marketCards.filter(Boolean).map(c => c.companyName);
+  const newCards     = deck.splice(0, 4);
+
+  state.marketCards             = newCards;
+  state.discardPiles.marketDeck = deck;
+
+  const logEvent = {
+    type:      'CEO_ABILITY',
+    ceoName:   'The Suit',
+    ability:   'SUIT_MARKET_REFRESH',
+    discarded,
+    newCards:  newCards.map(c => c.companyName),
+  };
+
+  return { logEvent };
+}
+
+/**
+ * The Gambler — ONCE_PER_YEAR reroll.
+ * Called after rolling one asset value die; the new result must be taken.
+ * If the new roll is strictly lower than the original, the RISK ability
+ * triggers: +1 stress.
+ * Returns { logEvent: null } if already used this year.
+ *
+ * @param {object} player
+ * @param {number} originalRoll  — d6 result to reroll
+ * @param {import('./dice.js').Dice} dice
+ * @returns {{ newRoll: number, oldRoll: number, stressGained: number, logEvent: object|null }}
+ */
+export function useGamblerReroll(player, originalRoll, dice) {
+  if (player.ceo?.ceoName !== 'The Gambler') {
+    return { newRoll: originalRoll, oldRoll: originalRoll, stressGained: 0, logEvent: null };
+  }
+
+  const as = abilityState(player);
+  if (as.gamblerRerollUsedThisYear) {
+    return { newRoll: originalRoll, oldRoll: originalRoll, stressGained: 0, logEvent: null };
+  }
+
+  as.gamblerRerollUsedThisYear = true;
+
+  const newRoll     = dice.d6();
+  const stressGained = newRoll < originalRoll ? 1 : 0;
+
+  if (stressGained > 0) {
+    player.stress += stressGained;
+  }
+
+  const logEvent = {
+    type:         'CEO_ABILITY',
+    ceoName:      'The Gambler',
+    ability:      'GAMBLER_REROLL',
+    oldRoll:      originalRoll,
+    newRoll,
+    stressGained,
+    newStress:    player.stress,
+  };
+
+  return { newRoll, oldRoll: originalRoll, stressGained, logEvent };
+}
+
+/**
+ * The Lobbyist — ONCE_PER_YEAR GMI adjustment.
+ * Called immediately after the global event card is drawn, before any asset
+ * values are updated.  Adjusts state.gmi by direction (+1 or -1).
+ * Returns { logEvent: null } if already used this year.
+ *
+ * @param {object} player
+ * @param {object} state      — GameState (mutated: state.gmi adjusted)
+ * @param {1|-1}   direction  — +1 or -1
+ * @returns {{ logEvent: object|null }}
+ */
+export function useLobbyistGMIAdjust(player, state, direction) {
+  if (player.ceo?.ceoName !== 'The Lobbyist') return { logEvent: null };
+
+  const as = abilityState(player);
+  if (as.lobbyistAdjustUsedThisYear) return { logEvent: null };
+
+  as.lobbyistAdjustUsedThisYear = true;
+
+  state.gmi += direction;
+
+  const logEvent = {
+    type:      'CEO_ABILITY',
+    ceoName:   'The Lobbyist',
+    ability:   'LOBBYIST_GMI_ADJUST',
+    direction,
+    newGmi:    state.gmi,
+  };
+
+  return { logEvent };
+}
+
+/**
+ * Clears all ONCE_PER_YEAR CEO ability flags at the end of each round.
+ * Should be called for every player during year-end cleanup.
+ *
+ * @param {object} player
+ */
+export function resetCEOYearlyAbilities(player) {
+  const as = abilityState(player);
+  as.gamblerRerollUsedThisYear    = false;
+  as.lobbyistAdjustUsedThisYear   = false;
+}

--- a/engine/events.js
+++ b/engine/events.js
@@ -1,0 +1,244 @@
+/**
+ * Global and personal event resolution.
+ *
+ * resolveGlobalEvent(card, state, dice)
+ *   → { gmiDelta, logEvents }
+ *   Handles:
+ *     • existing depression persistence/escape rolls
+ *     • GMI computation
+ *     • bubble pops (when GMI delta < 0)
+ *     • new bubble / depression registration
+ *     • STRESS_MODIFIER effects applied to all living players
+ *
+ * resolvePersonalEvent(card, player, state, dice)
+ *   → { logEvents }
+ *   IMMEDIATE  → apply immediateEffect now and discard
+ *   HOLD       → add to player.hand (player plays it voluntarily later)
+ *   PASSIVE    → add to player.hand (always-active rule)
+ */
+
+import { computeGMIDelta } from './gmi.js';
+
+/**
+ * d6 threshold at which each persistent depression ends (roll >= threshold).
+ * @private
+ */
+const DEPRESSION_ESCAPE_THRESHOLD = {
+  'Great Depression':  4,   // 4–6 escape
+  'Debt Crisis':       5,   // 5–6 escape
+  'Systemic Collapse': 6,   // 6 only
+};
+
+/**
+ * Resolves a drawn global event card against the current game state.
+ *
+ * Step order:
+ *   1. Roll for each active depression: escape or persist (+1 stress to all).
+ *   2. Compute GMI delta from the newly drawn card.
+ *   3. Pop any active bubble whose targetIndustry is affected when gmiDelta < 0:
+ *      all assets of that industry drop by 3.
+ *   4. Register the new card as an active bubble or depression (if persistent).
+ *   5. Apply any STRESS_MODIFIER effects from the new card to all living players.
+ *
+ * @param {object}                    card   — global event card
+ * @param {object}                    state  — GameState (mutated)
+ * @param {import('./dice.js').Dice}  dice
+ * @returns {{ gmiDelta: number, logEvents: object[] }}
+ */
+export function resolveGlobalEvent(card, state, dice) {
+  const logEvents = [];
+
+  // ── 1. Depression persistence / escape rolls ──────────────────────────────
+  const survivingDepressions = [];
+
+  for (const dep of (state.activeDepressions ?? [])) {
+    const threshold = DEPRESSION_ESCAPE_THRESHOLD[dep.eventName];
+    if (threshold === undefined) {
+      // Unknown depression type — keep it active, skip roll
+      survivingDepressions.push(dep);
+      continue;
+    }
+
+    const roll    = dice.d6();
+    const escaped = roll >= threshold;
+
+    if (escaped) {
+      logEvents.push({
+        type:      'DEPRESSION_ENDED',
+        eventName: dep.eventName,
+        roll,
+      });
+    } else {
+      // Persists — all living players gain +1 stress
+      for (const player of state.players) {
+        if (!player.alive) continue;
+        player.stress += 1;
+        logEvents.push({
+          type:      'STRESS_CHANGE',
+          playerId:  player.id,
+          delta:     1,
+          newStress: player.stress,
+          reason:    'DEPRESSION_PERSISTS',
+          source:    dep.eventName,
+        });
+      }
+      survivingDepressions.push(dep);
+      logEvents.push({
+        type:      'DEPRESSION_PERSISTS',
+        eventName: dep.eventName,
+        roll,
+      });
+    }
+  }
+  state.activeDepressions = survivingDepressions;
+
+  // ── 2. Compute GMI delta ──────────────────────────────────────────────────
+  const gmiDelta = computeGMIDelta(card, dice);
+  state.gmi     += gmiDelta;
+
+  logEvents.push({
+    type:      'GMI_UPDATE',
+    eventName: card.eventName,
+    gmiDelta,
+    newGmi:    state.gmi,
+  });
+
+  // ── 3. Pop bubbles when GMI delta is negative ─────────────────────────────
+  const survivingBubbles = [];
+
+  for (const bubble of (state.activeBubbles ?? [])) {
+    if (gmiDelta < 0) {
+      // Drop all assets in the bubble industry by 3 (floor 1)
+      for (const player of state.players) {
+        for (const asset of (player.assets ?? [])) {
+          if (asset.industry !== bubble.targetIndustry) continue;
+          const oldValue    = asset.currentValue ?? asset.baseValue;
+          asset.currentValue = Math.max(1, oldValue - 3);
+          logEvents.push({
+            type:     'BUBBLE_POP_ASSET_DROP',
+            assetId:  asset.companyName,
+            playerId: player.id,
+            industry: bubble.targetIndustry,
+            oldValue,
+            newValue: asset.currentValue,
+          });
+        }
+      }
+      logEvents.push({
+        type:           'BUBBLE_POPPED',
+        eventName:      bubble.eventName,
+        targetIndustry: bubble.targetIndustry,
+      });
+    } else {
+      survivingBubbles.push(bubble);
+    }
+  }
+  state.activeBubbles = survivingBubbles;
+
+  // ── 4. Register new persistent bubble or depression ───────────────────────
+  if (card.persistent) {
+    if (card.eventCategory === 'BUBBLE') {
+      state.activeBubbles.push(card);
+      logEvents.push({
+        type:           'BUBBLE_ACTIVATED',
+        eventName:      card.eventName,
+        targetIndustry: card.targetIndustry,
+      });
+    } else if (card.eventCategory === 'DEPRESSION') {
+      state.activeDepressions.push(card);
+      logEvents.push({
+        type:      'DEPRESSION_ACTIVATED',
+        eventName: card.eventName,
+      });
+    }
+  }
+
+  // ── 5. Apply STRESS_MODIFIER effects to all living players ────────────────
+  for (const effect of (card.effects ?? [])) {
+    if (effect.effectType !== 'STRESS_MODIFIER') continue;
+    for (const player of state.players) {
+      if (!player.alive) continue;
+      player.stress += effect.magnitude;
+      logEvents.push({
+        type:      'STRESS_CHANGE',
+        playerId:  player.id,
+        delta:     effect.magnitude,
+        newStress: player.stress,
+        reason:    'GLOBAL_EVENT',
+        source:    card.eventName,
+      });
+    }
+  }
+
+  return { gmiDelta, logEvents };
+}
+
+/**
+ * Resolves a personal event card drawn for a specific player.
+ *
+ * IMMEDIATE  — immediateEffect is applied now; card is consumed.
+ * HOLD       — card is added to player.hand; player plays it manually later.
+ * PASSIVE    — card is added to player.hand; its rule is always active while held.
+ *
+ * Supported immediateEffect types:
+ *   CASH_CHANGE  → player.cash  += magnitude
+ *   STRESS_CHANGE → player.stress += magnitude
+ *   Others       → recorded in the log but not mutated (caller responsible).
+ *
+ * @param {object} card    — personal event card
+ * @param {object} player  — receiving player (mutated for IMMEDIATE effects)
+ * @param {object} state   — GameState (available for future effect types)
+ * @param {import('./dice.js').Dice} dice
+ * @returns {{ logEvents: object[] }}
+ */
+export function resolvePersonalEvent(card, player, state, dice) {  // eslint-disable-line no-unused-vars
+  const logEvents = [];
+
+  if (card.playTiming === 'IMMEDIATE') {
+    const effect = card.immediateEffect;
+
+    if (effect) {
+      if (effect.effectType === 'CASH_CHANGE') {
+        player.cash += effect.magnitude;
+        logEvents.push({
+          type:       'PERSONAL_EVENT_APPLIED',
+          playerId:   player.id,
+          eventName:  card.eventName,
+          effectType: effect.effectType,
+          magnitude:  effect.magnitude,
+          newCash:    player.cash,
+        });
+      } else if (effect.effectType === 'STRESS_CHANGE') {
+        player.stress += effect.magnitude;
+        logEvents.push({
+          type:       'PERSONAL_EVENT_APPLIED',
+          playerId:   player.id,
+          eventName:  card.eventName,
+          effectType: effect.effectType,
+          magnitude:  effect.magnitude,
+          newStress:  player.stress,
+        });
+      } else {
+        // Other effect types recorded; caller applies them
+        logEvents.push({
+          type:       'PERSONAL_EVENT_APPLIED',
+          playerId:   player.id,
+          eventName:  card.eventName,
+          effectType: effect.effectType,
+        });
+      }
+    }
+  } else {
+    // HOLD or PASSIVE — add to hand
+    player.hand = player.hand ?? [];
+    player.hand.push(card);
+    logEvents.push({
+      type:        'PERSONAL_EVENT_HELD',
+      playerId:    player.id,
+      eventName:   card.eventName,
+      playTiming:  card.playTiming,
+    });
+  }
+
+  return { logEvents };
+}

--- a/engine/integration.js
+++ b/engine/integration.js
@@ -3,6 +3,12 @@
  *
  * computeIntegrationLoanBonus(asset, playerAssets)
  *   → total LOAN_CAPACITY_BONUS earned by `asset` from the player's portfolio
+ *
+ * detectIntegration(player)
+ *   → array of active bonus descriptors for the player's current portfolio
+ *
+ * applyIntegrationBonuses(player, bonuses)
+ *   → applies stressReduction bonuses; returns { logEvents }
  */
 
 /**
@@ -42,4 +48,134 @@ export function computeIntegrationLoanBonus(asset, playerAssets = []) {
   }
 
   return bonus;
+}
+
+/**
+ * Detects all active integration bonuses for a player's current portfolio.
+ *
+ * For each asset, scans its verticalIntegrationRules and crossIndustrySynergies.
+ * A rule is fulfilled when the player owns another asset matching
+ * { industry: rule.requiresIndustry, placement: rule.requiresPlacement }.
+ *
+ * The Operator CEO special rules:
+ *   1. When a vertical integration rule is active on an asset, the Operator
+ *      may also activate ONE cross-industry synergy on that same asset without
+ *      owning the required asset (operatorActivated=true on that bonus).
+ *   2. All stressReduction values from vertical integration rules are doubled.
+ *
+ * @param {object} player  — must have player.assets and player.ceo
+ * @returns {Array<{
+ *   assetId: string,
+ *   rule: object,
+ *   effectType: string,
+ *   effectMagnitude: number,
+ *   stressReduction: number,
+ *   source: 'VERTICAL'|'CROSS_INDUSTRY',
+ *   operatorActivated?: boolean,
+ * }>}
+ */
+export function detectIntegration(player) {
+  const assets      = player.assets ?? [];
+  const isOperator  = player.ceo?.ceoName === 'The Operator';
+  const bonuses     = [];
+
+  for (const asset of assets) {
+    const others = assets.filter(a => a.companyName !== asset.companyName);
+
+    // ── Vertical integration rules ────────────────────────────────────────────
+    let hasActiveVertical = false;
+
+    for (const rule of (asset.verticalIntegrationRules ?? [])) {
+      if (!rule.requiresIndustry || !rule.requiresPlacement) continue;
+
+      const fulfilled = others.some(
+        a => a.industry === rule.requiresIndustry &&
+             a.placement === rule.requiresPlacement,
+      );
+      if (!fulfilled) continue;
+
+      hasActiveVertical = true;
+      // The Operator doubles stressReduction on vertical rules
+      const stressReduction = isOperator
+        ? (rule.stressReduction ?? 0) * 2
+        : (rule.stressReduction ?? 0);
+
+      bonuses.push({
+        assetId: asset.companyName,
+        rule,
+        effectType:       rule.effectType,
+        effectMagnitude:  rule.effectMagnitude ?? 0,
+        stressReduction,
+        source:           'VERTICAL',
+      });
+    }
+
+    // ── Cross-industry synergies ───────────────────────────────────────────────
+    let operatorFreeUsed = false;
+
+    for (const rule of (asset.crossIndustrySynergies ?? [])) {
+      if (!rule.requiresIndustry || !rule.requiresPlacement) continue;
+
+      const fulfilled = others.some(
+        a => a.industry === rule.requiresIndustry &&
+             a.placement === rule.requiresPlacement,
+      );
+
+      // The Operator may activate ONE free cross-industry synergy per asset
+      // when at least one vertical integration is already active on that asset.
+      const operatorFree = isOperator && hasActiveVertical && !operatorFreeUsed && !fulfilled;
+
+      if (!fulfilled && !operatorFree) continue;
+
+      if (operatorFree) operatorFreeUsed = true;
+
+      bonuses.push({
+        assetId:          asset.companyName,
+        rule,
+        effectType:       rule.effectType,
+        effectMagnitude:  rule.effectMagnitude ?? 0,
+        stressReduction:  rule.stressReduction ?? 0,
+        source:           'CROSS_INDUSTRY',
+        ...(operatorFree ? { operatorActivated: true } : {}),
+      });
+    }
+  }
+
+  return bonuses;
+}
+
+/**
+ * Applies the stressReduction component of a set of integration bonuses.
+ * Stress cannot drop below the CEO's startingStress.
+ * Mutates player directly.
+ *
+ * @param {object} player
+ * @param {Array}  bonuses  — from detectIntegration()
+ * @returns {{ logEvents: object[] }}
+ */
+export function applyIntegrationBonuses(player, bonuses) {
+  const logEvents = [];
+  const floor     = player.ceo?.startingStress ?? 0;
+
+  for (const bonus of bonuses) {
+    const reduction = bonus.stressReduction ?? 0;
+    if (reduction <= 0) continue;
+
+    const oldStress   = player.stress;
+    player.stress     = Math.max(floor, player.stress - reduction);
+    const actualDelta = player.stress - oldStress;   // negative or zero
+
+    if (actualDelta !== 0) {
+      logEvents.push({
+        type:           'INTEGRATION_BONUS',
+        playerId:       player.id,
+        assetId:        bonus.assetId,
+        effectType:     bonus.effectType,
+        stressReduction: -actualDelta,
+        newStress:      player.stress,
+      });
+    }
+  }
+
+  return { logEvents };
 }

--- a/engine/market.js
+++ b/engine/market.js
@@ -1,0 +1,109 @@
+/**
+ * Market initialisation and auction resolution.
+ *
+ * initMarket(state, marketDeck)
+ *   → populates state.marketCards (top 4) and state.discardPiles.marketDeck (remainder)
+ *
+ * auctionAsset(card, players, agentBids, state)
+ *   → { winner, winningBid, logEvent }
+ *   Resolves a single auction slot: highest bid >= baseValue wins.
+ *   Tie-break: first player in the `players` array.
+ *   Winning player's cash is deducted, asset is added to their portfolio,
+ *   starter asset is discarded (unless The Heir), and the market slot is
+ *   refilled from the remaining deck.
+ */
+
+/**
+ * Populates the initial market state from a pre-shuffled deck.
+ * The first 4 cards become the face-up market; the rest are stored as the
+ * remaining draw pile in state.discardPiles.marketDeck.
+ * Mutates state directly.
+ *
+ * @param {object}   state       — GameState
+ * @param {object[]} marketDeck  — full shuffled market deck
+ */
+export function initMarket(state, marketDeck) {
+  state.marketCards               = marketDeck.slice(0, 4);
+  state.discardPiles.marketDeck   = marketDeck.slice(4);
+}
+
+/**
+ * Resolves the auction for a single market card.
+ *
+ * Rules:
+ *   - A bid is only valid when bid >= card.baseValue.
+ *   - The player with the highest valid bid wins.
+ *   - Tie-break: first player in the `players` array order.
+ *   - On a win:
+ *       • winner.cash  -= winningBid
+ *       • asset is added to winner.assets (currentValue = baseValue)
+ *       • winner.stress += asset.stress  (asset stress applied immediately)
+ *       • starter asset discarded unless ceo === 'The Heir'
+ *       • market slot refilled from state.discardPiles.marketDeck (if available)
+ *   - Returns { winner: null, winningBid: 0, logEvent: null } if no valid bid.
+ *
+ * @param {object}   card       — market card being auctioned
+ * @param {object[]} players    — all living players in turn order
+ * @param {object}   agentBids  — { [playerId]: number }  bid amounts
+ * @param {object}   state      — GameState (mutated for market slot refresh)
+ * @returns {{ winner: object|null, winningBid: number, logEvent: object|null }}
+ */
+export function auctionAsset(card, players, agentBids, state) {
+  let winner     = null;
+  let winningBid = 0;
+
+  for (const player of players) {
+    if (!player.alive) continue;
+    const bid = agentBids[player.id] ?? 0;
+    if (bid >= card.baseValue && bid > winningBid) {
+      winner     = player;
+      winningBid = bid;
+    }
+  }
+
+  if (!winner) {
+    return { winner: null, winningBid: 0, logEvent: null };
+  }
+
+  // ── Deduct cash ───────────────────────────────────────────────────────────
+  winner.cash -= winningBid;
+
+  // ── Add asset (currentValue initialised to baseValue) ────────────────────
+  const acquiredAsset = { ...card, currentValue: card.baseValue };
+  winner.assets.push(acquiredAsset);
+
+  // ── Apply asset stress ────────────────────────────────────────────────────
+  winner.stress += card.stress ?? 0;
+
+  // ── Discard starter asset (unless The Heir keeps it forever) ─────────────
+  if (winner.starterAsset !== null && winner.ceo?.ceoName !== 'The Heir') {
+    winner.starterAsset = null;
+  }
+
+  // ── Refill market slot ────────────────────────────────────────────────────
+  const slotIndex = state.marketCards.findIndex(
+    c => c && c.companyName === card.companyName,
+  );
+  const deck = state.discardPiles.marketDeck ?? [];
+
+  if (slotIndex !== -1) {
+    if (deck.length > 0) {
+      state.marketCards[slotIndex]       = deck.shift();
+      state.discardPiles.marketDeck      = deck;
+    } else {
+      state.marketCards[slotIndex]       = null;
+    }
+  }
+
+  const logEvent = {
+    type:        'ASSET_PURCHASED',
+    playerId:    winner.id,
+    assetId:     card.companyName,
+    bid:         winningBid,
+    newCash:     winner.cash,
+    stressDelta: card.stress ?? 0,
+    newStress:   winner.stress,
+  };
+
+  return { winner, winningBid, logEvent };
+}


### PR DESCRIPTION
Add four engine modules for the next layer of Borrow & Die game mechanics:

- engine/integration.js: add detectIntegration(player) and applyIntegrationBonuses(player, bonuses); The Operator doubles vertical stressReduction and unlocks one free cross-industry synergy per asset when a vertical bonus is already active.

- engine/market.js: initMarket(state, deck) exposes top-4 cards and stores the remainder in state.discardPiles.marketDeck; auctionAsset resolves highest-bid-wins with tie-break by player order, deducts cash, adds asset, applies stress, discards starter (unless The Heir), refills slot.

- engine/events.js: resolveGlobalEvent handles depression escape rolls, GMI computation, bubble pops (gmiDelta < 0), new bubble/depression registration, and STRESS_MODIFIER effects; resolvePersonalEvent routes IMMEDIATE (apply now), HOLD, and PASSIVE (both → player.hand) cards.

- engine/ceo.js: applyCEOAbilities dispatches phase-specific passives (Worker bonus income, Short Seller negative-GMI cash, Influencer stress→media value, Visionary stagnation risk); useSuitMarketRefresh, useGamblerReroll, useLobbyistGMIAdjust are explicit once-per-game/year activators; resetCEOYearlyAbilities clears per-year flags.

https://claude.ai/code/session_019pzKTpKYCodvL9h49fACai