### PR TITLE
Add .claude/ignore file to exclude non-core files

### DIFF
--- a/.claude/ignore
+++ b/.claude/ignore
@@ -1,0 +1,9 @@
+# Non-core files — ignored by Claude
+README.md
+package-lock.json
+
+# Static data / card definitions
+data/
+
+# Scenario config files (not source code)
+scenarios/*.json


### PR DESCRIPTION
## Summary
Added a `.claude/ignore` configuration file to specify which files and directories should be ignored by Claude when analyzing the codebase.

## Key Changes
- Created `.claude/ignore` file with patterns for non-essential files and directories
- Configured to exclude documentation (README.md) and dependency lockfiles (package-lock.json)
- Excluded static data files in the `data/` directory
- Excluded scenario configuration files (JSON files in `scenarios/` directory)

## Details
This configuration helps focus Claude's analysis on actual source code by filtering out:
- Documentation and metadata files
- Generated dependency lockfiles
- Static data and configuration artifacts

This improves the signal-to-noise ratio when Claude processes the repository.

https://claude.ai/code/session_01U6Vsi3b7ziDxFDiWTQtZk2