### PR TITLE
Refactor README and add smoke test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,312 +1,215 @@
-# Capital-Death-Taxes
- Borrow &amp; Die is a strategy board game in active design. The core theme is wealth-building through asset leverage: players buy assets, borrow against them, offset taxable income with loan draws, and try to maximise their net asset value before they die.
-# Borrow & Die — Simulation Architecture & Claude Code Agent Prompts
+# Borrow & Die — Simulator
 
-# Borrow & Die — Project Description
-
-## What this project is
-
-Borrow & Die is a strategy board game in active design. The core theme is wealth-building through asset leverage: players buy assets, borrow against them, offset taxable income with loan draws, and try to maximise their net asset value before they die. The game is a teaching tool as much as a game — it simulates the financial dynamics used by the ultra-wealthy to grow wealth without ever realising (and therefore taxing) gains.
-
-The project consists of a complete card game design including all card data in JSON schema format, card visual mockups in HTML, and a full design rationale developed through iterative conversation. It is ready for physical playtesting.
-
----
-
-## Core scoring formula
+Deterministic card-game simulator for **Borrow & Die**, a board game about wealth-building through asset leverage. Players buy assets, borrow against them, offset taxable income with loan draws, and try to maximise net asset value before they die.
 
 ```
 Final Score = Total Asset Value – Total Taxes Paid
 ```
 
-Players win by owning the most paper wealth while paying the least tax. Income is the enemy. Leverage is the strategy.
-
 ---
 
-## Game arc
+## Setup
 
-**Labor phase** — no assets owned. Players earn CEO income ($0–$3/yr) and try to buy their first asset.
+**Requirements:** Node.js 18+
 
-**Growth phase** — 1–2 assets. Building loan capacity, managing stress, minimising taxable income.
-
-**Legacy phase** — 3 assets owned and/or stress reaches death roll threshold. Death rolls begin (d6, 1–2 = death, 3–6 = survive).
-
-**End trigger** — first player death triggers one final round for all remaining players, then final scoring.
-
----
-
-## Key mechanics
-
-### Asset Value
-`Asset Value = running total, updated each year by: GMI delta + deltaLocalValue (d6 roll)`
-
-Base Value is fixed at purchase (the IPO price). Local Value accumulates from annual d6 rolls. GMI is a shared annual delta applied to every asset.
-
-### Loans and loan capacity
-- Loan capacity tracked with a red peg per asset. Grows by `loanCapacityIncreasePer10AssetValue` each time asset value crosses a +10 boundary.
-- Loans drawn tracked with a black peg. Cannot exceed red peg position.
-- Collateral violation: black peg exceeds red peg → must resolve immediately (repay, restructure, or forced sale).
-- Annual settlement: roll d6 per 10 loan units. Trigger = pay $1 + remove 1 loan. Roll of 6 = remove 1 loan free.
-
-### Taxes
-- Flat 50% rate on net taxable income.
-- First $1 always tax-free.
-- Every $1 borrowed this year offsets $1 of income before tax calculation.
-- Never reset through bankruptcy. Permanent score penalty.
-
-### Stress and death
-- Stress accumulates from: acquiring assets (printed stress value on card), bankruptcy (+2), global/personal event cards.
-- Stress removed by: selling assets, integration bonuses, held personal event cards.
-- Death roll triggers when stress ≥ threshold (default 6, Bureaucrat CEO = 8).
-- Death roll: d6. 1–2 = death. 3–6 = survive.
-
-### GMI (Global Market Index)
-- Shared delta applied to all assets every year.
-- Set by global event card drawn at year start.
-- Categories: Bull Run (+4 base, d6 modifier), Boom (+2 flat), Normal (+1), Flat (0 base, d6 modifier), Correction (–1), Recession (–2), Depression (–2 persistent face-up card).
-- d6 modifier rule where applicable: 1–2 = –1, 3–4 = 0, 5–6 = +1.
-
-### Bankruptcy
-- Triggered when loans cannot be resolved and no assets remain.
-- Cash resets to `max(5, GMI + 5)`.
-- All assets and loans wiped. Stress +2. Taxes paid remain.
-- Player must reselect a CEO card from available options.
-
----
-
-## Turn sequence (per year)
-
-```
-YEAR START (shared, once)
-  1. Draw global event card → apply GMI to all assets
-  2. Market refresh if applicable
-
-ROUND ROBIN (rotating starting player each year)
-  3. Auction — 4 market cards exposed, min bid = Base Value
-  4. Personal actions — draw personal event card, roll value updates per asset
-  5. Settlement (free-form within turn):
-       sell assets · take out loans · repayment roll · repay loans
-       pay taxes · death roll check if stress ≥ threshold
+```bash
+npm install
+node cli/run.js --help
 ```
 
 ---
 
-## Card inventory
+## Run a simulation
 
-| Card type | Count | Notes |
-|---|---|---|
-| Asset cards | 50 | 20 T1, 23 T2, 7 T3 across 6 industries + 8 hybrids |
-| CEO cards (original) | 6 | Worker, Suit, Gambler, Visionary, Bureaucrat, Raider |
-| CEO cards (expansion) | 6 | Tax Attorney, Lobbyist, Influencer, Operator, Heir, Short Seller |
-| Global event cards | 50 | 10 drawn per game |
-| Personal event cards | 50 | ~40 drawn per 4-player game |
+```bash
+# 100 runs of the standard 4-player scenario (results saved to output/runs/)
+node cli/run.js --scenario default-4p --runs 100
 
----
+# Single run with step-by-step output (press Enter each round)
+node cli/run.js --scenario default-4p --runs 1 --step
 
-## Industries (asset cards)
-
-Each industry has a unique mechanical identity:
-
-| Industry | Identity | Unique mechanic |
-|---|---|---|
-| Technology | Paper wealth engine | Weak loans; integration unlocks lender confidence |
-| Energy | GMI-sensitive income trap | GMI applied double (or triple for T3) |
-| Real Estate | The floor — stable, high LTV | Highest base loan capacity; once-per-game refinancing |
-| Finance | Meta-industry — manipulates loans | Modifies repayment rules on other assets; asymmetric depression mechanic |
-| Manufacturing | GMI-resistant grinder | GMI halved; full-stack ignores one depression delta |
-| Media & Entertainment | Wild card — buzz die | Roll twice per year, take higher or lower based on buzz die |
-
-**Hybrid cards (8)** span two industries simultaneously, enabling cross-sector combos.
-
----
-
-## Vertical integration
-
-Owning 2 of 3 placements (Upstream/Midstream/Downstream) in one industry activates one integration bonus. All 3 activates both. Bonuses include: loan capacity increases, crash floors, repayment relief, stress reduction, income offset, free loan restructuring.
-
-Cross-industry synergies also exist — e.g. Real Estate + Finance unlocks leveraged property fund mechanics; Technology + Media unlocks streaming platform loan capacity.
-
----
-
-## CEO cards
-
-All 12 CEOs are permanent identities — no upgrading. Selected at game start by auction (min $0 bid). Replaced only on bankruptcy or via specific card effects.
-
-Each CEO has:
-- Base annual income ($0–$3)
-- Starting stress (0–3)
-- Death roll threshold (6 for most, 8 for Bureaucrat)
-- T3 access rule (standard: requires owning one T2; Visionary: unrestricted)
-- 2 abilities (passive, triggered, once-per-year, once-per-game, or risk)
-- A starter asset (flat, weak, does not occupy an asset slot — discarded on first market purchase; passive reassignment transfers one ability to first purchased asset)
-
-**Exception:** The Heir's starter asset is permanent, occupies a full asset slot from game start, and is only removed by voluntary sale.
-
----
-
-## Global event cards
-
-50 cards, 10 drawn per game. Categories:
-- Boom (×6) — GMI +2, one industry gets +1 to all value update rolls
-- Bull Run (×2) — GMI +4 base with d6 modifier, strong secondary effects
-- Normal (×10) — GMI +1, minor secondary effects
-- Flat (×6) — GMI 0 with d6 modifier, friction effects
-- Correction (×8) — GMI –1, sector pressure
-- Recession (×6) — GMI –2, systemic effects
-- Depression (×3) — GMI –2 persistent face-up; roll to escape each year; failed escape = all players +1 stress
-- Bubble (×3) — industry-specific; raises delta floor while active; pops on next negative GMI, dealing –3 immediate value + collateral pressure
-- Stress Event (×3) — all players +1 stress immediately; rarest category
-- Wildcard (×3) — unusual effects (turn order reversal, player-set GMI, forced CEO replacement)
-
----
-
-## Personal event cards
-
-50 cards, ~40 drawn per 4-player game. Timings: IMMEDIATE (resolves on draw), HOLD (player decides when to play or sell for $1), PASSIVE (always-on, auto-discards on trigger).
-
-Categories: Stress Relief (×8), Death Prevention (×4), Cash Windfall (×6), Cash Drain (×4), Tax Event (×5), Loan Event (×6), Market Manipulation (×5), Dice Modifier (×4), Asset Event (×2), Information & Social (×4), Legacy Effect (×2).
-
----
-
-## Files in this project
-
-| File | Contents |
-|---|---|
-| `card.schema.json` | Full JSON schema for all card types |
-| `SCHEMA_REFERENCE.md` | Annotated schema guide with examples and design rules |
-| `CONSOLIDATED_RULE_SET` | Core rules reference |
-| `Turn_Sequence` | Formal turn sequence |
-| `ceo-cards.json` | Original 6 CEO cards with starter assets |
-| `ceo-cards-new-6.json` | Expansion 6 CEO cards with starter assets |
-| `energy-cards.json` | 7 Energy sector asset cards |
-| `technology-cards.json` | 7 Technology sector asset cards |
-| `real-estate-cards.json` | 7 Real Estate sector asset cards |
-| `finance-cards.json` | 7 Finance sector asset cards |
-| `manufacturing-cards.json` | 7 Manufacturing sector asset cards |
-| `media-cards.json` | 7 Media & Entertainment sector asset cards |
-| `hybrid-cards.json` | 8 hybrid/cross-industry asset cards |
-| `global-event-cards.json` | 50 Global Event cards |
-| `personal-event-cards.json` | 50 Personal Event cards |
-| `*-card-mockup.html` | Interactive card viewer for each sector |
-
- 
-## Technical Overview
- 
-This document contains everything needed to spin up a Claude Code-powered playtest simulator in a GitHub repo. It covers:
- 
-1. **Repo architecture** — folder structure and module responsibilities
-2. **Priority metrics** — what to measure and why
-3. **Agent prompts** — copy-paste instructions for Claude Code across each build phase
-4. **Dashboard spec** — how metrics are visualized and recorded
- 
----
- 
-## 1. Repo Architecture
- 
+# List all available scenarios
+node cli/run.js --list-scenarios
 ```
-borrow-and-die-sim/
-├── data/
-│   ├── cards/                  # Copy all JSON card files here
-│   │   ├── energy-cards.json
-│   │   ├── finance-cards.json
-│   │   ├── manufacturing-cards.json
-│   │   ├── media-cards.json
-│   │   ├── real-estate-cards.json
-│   │   ├── technology-cards.json
-│   │   ├── hybrid-cards.json
-│   │   ├── ceo-cards.json
-│   │   ├── global-event-cards.json
-│   │   └── personal-event-cards.json
-│   └── schema/
-│       └── card_schema.json
-├── engine/
-│   ├── state.js                # GameState class — single source of truth
-│   ├── deck.js                 # Deck builders and shufflers
-│   ├── dice.js                 # Deterministic dice module (seeded RNG)
-│   ├── gmi.js                  # GMI computation and application
-│   ├── asset.js                # Asset value update logic per industry mechanic
-│   ├── loans.js                # Loan capacity, draw, repayment check
-│   ├── taxes.js                # Tax computation and offset calculation
-│   ├── stress.js               # Stress tracking, death roll, bankruptcy
-│   ├── market.js               # Market auction simulation
-│   ├── events.js               # Global and personal event resolution
-│   ├── ceo.js                  # CEO ability application
-│   ├── integration.js          # Vertical integration and cross-industry synergy detection
-│   └── turn.js                 # Full year turn runner — orchestrates all phases
-├── agents/
-│   ├── base-agent.js           # Abstract player agent interface
-│   ├── conservative-agent.js   # Buys RE/Mfg, manages stress, rarely T3
-│   ├── aggressive-agent.js     # Chases T3, leverages hard, accepts death risk
-│   ├── tech-stack-agent.js     # Tries to complete vertical tech integration
-│   ├── income-agent.js         # Maximizes income (tests the income trap thesis)
-│   └── random-agent.js         # Uniformly random legal moves (baseline/chaos)
-├── scenarios/
-│   ├── scenario-runner.js      # Loads a scenario config, runs N games, returns metrics
-│   ├── default-4p.json         # Standard 4-player game
-│   ├── tech-only-market.json   # Market seeded with only tech cards (stress test)
-│   ├── depression-heavy.json   # Global event deck weighted toward depression cards
-│   └── max-leverage.json       # All agents play aggressive (collateral pressure test)
-├── metrics/
-│   ├── collector.js            # Attaches hooks to engine events, records every state change
-│   ├── aggregator.js           # Aggregates raw event log into metric summaries
-│   └── metrics-spec.json       # Canonical list of tracked metrics (see Section 2)
-├── dashboard/
-│   ├── index.html              # Single-page dashboard (no framework, vanilla JS)
-│   ├── charts.js               # Chart.js chart builders
-│   ├── run-table.js            # Per-run results table
-│   └── replay.js               # Step-through replay viewer
-├── cli/
-│   └── run.js                  # CLI: `node cli/run.js --scenario default-4p --runs 100`
-├── output/
-│   └── runs/                   # JSON run logs auto-saved here
-├── README.md
-└── package.json
-```
- 
+
+Output JSON is saved to `output/runs/<scenario>-<timestamp>-<seed>.json`.
+
 ---
- 
-## 2. Priority Metrics
- 
-These are the metrics that matter most for validating the design thesis. Each has a **health target**, a **red flag threshold**, and the **design question it answers**.
- 
-### Tier A — Game Health (must be in v1 dashboard)
- 
-| Metric ID | What it measures | Health target | Red flag | Design question |
-|---|---|---|---|---|
-| `first_asset_round` | Round number when first asset is purchased (per player) | ≤ 4 | > 6 | Is the labor phase too long? |
-| `first_death_roll_round` | Round of first death roll across all players | 6–8 | < 4 or > 10 | Is stress accumulation calibrated? |
-| `game_length_rounds` | Total rounds until end trigger fires | ~10 | < 6 or > 14 | Is the end trigger working? |
+
+## Run the smoke tests
+
+```bash
+npm test
+# or
+node test/smoke.js
+```
+
+Runs 110 games total (10 for basic sanity + 100 for d6 coverage) and prints `PASS`/`FAIL` per assertion.
+
+---
+
+## Open the dashboard
+
+> The dashboard is a work in progress. The `dashboard/` folder is a placeholder.
+
+Once `dashboard/index.html` exists:
+1. Run a simulation to generate a JSON file in `output/runs/`
+2. Open `dashboard/index.html` in a browser
+3. Load the JSON file via the file picker
+
+---
+
+## How to add a new scenario
+
+1. Copy an existing scenario file:
+   ```bash
+   cp scenarios/default-4p.json scenarios/my-scenario.json
+   ```
+
+2. Edit `scenarios/my-scenario.json`:
+   ```json
+   {
+     "scenarioName": "my-scenario",
+     "seed": "my-unique-seed",
+     "runs": 100,
+     "players": [
+       { "id": "p1", "agentType": "conservative", "ceoBid": 0 },
+       { "id": "p2", "agentType": "aggressive",   "ceoBid": 2 }
+     ],
+     "industries": ["TECHNOLOGY", "REAL_ESTATE", "ENERGY", "FINANCE", "MANUFACTURING", "MEDIA"],
+     "startingCash": 3,
+     "globalEventDeckBias": null,
+     "marketSeed": null
+   }
+   ```
+
+   | Field | Description |
+   |-------|-------------|
+   | `seed` | Base RNG seed; each run gets `${seed}-run${i}` |
+   | `agentType` | One of: `conservative`, `aggressive`, `tech-stack`, `income`, `random` |
+   | `ceoBid` | Fixed bid for CEO auction (overrides agent strategy) |
+   | `globalEventDeckBias` | e.g. `{ "DEPRESSION": 3 }` weights depression cards ×3 |
+   | `marketSeed` | Optional separate seed to fix market card layout |
+
+3. Run it:
+   ```bash
+   node cli/run.js --scenario my-scenario
+   ```
+
+---
+
+## How to add a new agent
+
+1. Create `agents/my-agent.js` extending `BaseAgent`:
+
+   ```js
+   import { BaseAgent } from './base-agent.js';
+
+   export class MyAgent extends BaseAgent {
+     constructor(id, opts = {}) {
+       super(id, opts);
+     }
+
+     // Required: return bid amounts keyed by companyName (or ceoName for CEOs)
+     // Return 0 or omit to pass. Bid must be >= card.baseValue for market cards.
+     bidOnAsset(card, player, state) {
+       return card.baseValue;  // always bid exactly baseValue
+     }
+
+     // Required: 'PLAY', 'HOLD', or 'SELL'
+     choosePersonalEventAction(card, player, state) {
+       return 'HOLD';
+     }
+
+     // Required: return assetId to sell, or null
+     chooseSellAsset(player, state) {
+       return null;
+     }
+
+     // Required: return number of loan tokens to draw this year
+     chooseLoanDraw(player, state) {
+       return 0;
+     }
+   }
+   ```
+
+2. Register it in `scenarios/scenario-runner.js`:
+
+   ```js
+   import { MyAgent } from '../agents/my-agent.js';
+
+   const AGENT_CLASSES = {
+     // ... existing entries ...
+     'my-agent': MyAgent,
+   };
+   ```
+
+3. Use `"agentType": "my-agent"` in a scenario file.
+
+Agent decisions are logged to `agent.decisions[]` automatically by `BaseAgent`. See `agents/base-agent.js` for the full interface including optional hooks (`lobbyistDirection`, `gamblerWantsReroll`, `beforeAuction`).
+
+---
+
+## Tracked metrics
+
+All metrics are extracted by `metrics/collector.js` after each game and returned in `results[].metrics`.
+
+### Tier A — Game Health
+
+| Metric | What it measures | Health target | Red flag | Design question |
+|--------|-----------------|---------------|----------|-----------------|
+| `first_asset_round` | Round when first asset is purchased | ≤ 4 | > 6 | Is the labor phase too long? |
+| `first_death_roll_round` | Round of first death roll | 6–8 | < 4 or > 10 | Is stress accumulation calibrated? |
+| `game_length_rounds` | Total rounds until end trigger | ~10 | < 6 or > 14 | Is the end trigger working? |
 | `bankruptcy_count` | Bankruptcies per game | ~1 | 0 or > 3 | Is bankruptcy a real threat or inevitable? |
-| `collateral_violation_count` | Times black peg exceeded red peg | 1–3 | 0 or > 6 | Is leverage dangerous enough but not punishing? |
+| `collateral_violation_count` | Times loans exceeded capacity | 1–3 | 0 or > 6 | Is leverage dangerous enough but not punishing? |
 | `death_count` | Deaths per game | 1 | 0 or > 2 | Does the mortality mechanic fire? |
- 
-### Tier B — Economic Balance (should be in v1 dashboard)
- 
-| Metric ID | What it measures | Health target | Red flag | Design question |
-|---|---|---|---|---|
-| `final_score_by_ceo` | Net score (asset value – taxes) per CEO archetype | No archetype > 20% win rate advantage | One archetype wins > 40% | Are CEOs balanced? |
-| `final_score_by_industry` | Net asset value per industry in winning portfolio | No single industry dominates | One industry in 3+ consecutive wins | Is any strategy dominant? |
-| `income_trap_rate` | % of players with high income who score below median | Should be > 50% | < 30% | Is income actually a trap? |
-| `tax_offset_rate` | % of income successfully offset via loans | 40–80% | < 20% or > 90% | Is the tax system engaging or trivially solved? |
-| `integration_achieved_rate` | % of games where at least one player completes a vertical stack | 40–60% | < 20% or > 80% | Is integration achievable but not trivial? |
-| `t3_acquisition_rate` | % of players who buy at least one T3 card | 30–60% | < 10% or > 80% | Is Tier 3 accessible but not default? |
- 
-### Tier C — Asset Dynamics (useful for deeper balance analysis)
- 
-| Metric ID | What it measures | Health target | Red flag | Design question |
-|---|---|---|---|---|
-| `asset_value_trajectory` | Mean asset value curve per industry over rounds | Divergent curves per industry | All industries converge to same trajectory | Do industries feel different? |
-| `loan_capacity_utilization` | Mean (loans drawn / max capacity) at game end | 50–80% | < 20% or > 95% | Are loans being used? Is LTV meaningful? |
-| `gmi_distribution` | Histogram of GMI deltas across simulated games | Roughly bell-shaped, centered near 0 | Persistent positive bias | Is the market neutral? |
-| `stress_at_death_roll` | Stress level when first death roll fires | 6–8 (per threshold) | Always exactly 6 | Do players accumulate stress from multiple sources or just from assets? |
-| `personal_event_sell_rate` | % of HOLD cards sold vs played for effect | Target: < 60% sold | > 80% sold | Are HOLD cards worth keeping? |
-| `buzz_die_impact` | Media asset value variance vs other industries | Higher variance than others | Same variance as RE | Is the buzz die creating meaningful volatility? |
- 
-### Tier D — Synergy Validation (post-playtest focus)
- 
-| Metric ID | What it measures | Health target | Red flag | Design question |
-|---|---|---|---|---|
-| `integration_bonus_stress_relief` | Mean stress reduction from integration bonuses | Noticeable but not game-breaking | Integration makes stress go negative | Are integration bonuses survivability tools, not win buttons? |
-| `cross_industry_synergy_rate` | How often cross-industry synergies are active | Present in ~30% of games | Never active | Are synergies discoverable? |
-| `tech_loan_unlock_rate` | How often tech stack achieves integration-unlocked loan capacity | Meaningful but slow | Tech players always cash-poor | Is tech's loan constraint felt but solvable? |
- 
+
+### Tier B — Economic Balance
+
+| Metric | What it measures | Health target | Red flag | Design question |
+|--------|-----------------|---------------|----------|-----------------|
+| `final_score_by_player` | Net score (asset value – taxes) per CEO archetype | No archetype > 20% win rate advantage | One archetype wins > 40% | Are CEOs balanced? |
+| `income_vs_score` | Income vs final score correlation | High income players score below median > 50% | < 30% | Is income actually a trap? |
+| `tax_offset_by_player` | % of income offset via loans | 40–80% | < 20% or > 90% | Is the tax system engaging or trivially solved? |
+| `has_vertical_stack` | Any player completed full vertical integration | 40–60% of games | < 20% or > 80% | Is integration achievable but not trivial? |
+| `t3_acquisitions` | Players who bought at least one T3 card | 30–60% | < 10% or > 80% | Is Tier 3 accessible but not default? |
+
+### Tier C — Asset Dynamics
+
+| Metric | What it measures | Health target | Red flag | Design question |
+|--------|-----------------|---------------|----------|-----------------|
+| `asset_value_trajectories` | Mean asset value curve per industry | Divergent curves per industry | All industries converge | Do industries feel different? |
+| `loan_utilization_by_player` | Mean loans drawn / max capacity | 50–80% | < 20% or > 95% | Are loans being used? Is LTV meaningful? |
+| `gmi_by_round` | GMI deltas across simulated games | Roughly bell-shaped near 0 | Persistent positive bias | Is the market neutral? |
+| `stress_at_death_roll` | Stress level when first death roll fires | 6–8 (per threshold) | Always exactly 6 | Do players accumulate stress from multiple sources? |
+| `personal_event_actions` | % of HOLD cards sold vs played | < 60% sold | > 80% sold | Are HOLD cards worth keeping? |
+| `integration_bonuses_fired` | Integration bonus activations per game | Present but not dominant | Never or always active | Are bonuses survivability tools, not win buttons? |
+
 ---
+
+## Known limitations
+
+- **CEO abilities are approximated.** Complex ability chains (e.g. The Gambler's reroll adjusts the dice sequence but does not fully re-evaluate the outcome table). Multi-step CEO interactions may need manual review for edge cases.
+
+- **No UI for live run monitoring.** The CLI prints progress every 10% for multi-run batches, but there is no real-time dashboard during a run. The `dashboard/` folder is a placeholder for a future viewer.
+
+- **Players can accumulate negative cash.** The engine debits taxes and loan repayments even when a player has insufficient cash. Bankruptcy is only triggered by collateral violations (loans exceeding capacity), not by zero cash. A high-income player with no cash reserves will gradually accumulate a tax-debt deficit without triggering bankruptcy. The smoke test flags only catastrophic values (below `-(round × 5)`).
+
+- **GMI buy/sell pressure is disabled (v1 simplification).** In the physical game, GMI movements are intended to create secondary buy/sell pressure on the market row. This pressure mechanic is not implemented in the v1 simulator per the original design doc. Asset value updates apply the GMI delta directly without modelling market sentiment flows.
+
+---
+
+## Project structure
+
+```
+├── agents/               # Agent implementations (conservative, aggressive, tech-stack, income, random)
+├── cli/run.js            # CLI entry point
+├── dashboard/            # Placeholder for browser-based visualiser
+├── data/cards/           # Card definitions in JSON (assets, CEOs, events)
+├── engine/               # Core game engine (state, turn, dice, assets, loans, taxes, stress …)
+├── metrics/              # Per-game metric extraction and aggregation
+├── output/runs/          # Auto-saved JSON run outputs
+├── scenarios/            # Scenario configs + scenario runner
+└── test/smoke.js         # Smoke test (npm test)
+```

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node test/smoke.js"
   },
   "dependencies": {
     "chart.js": "^4.4.0",

--- a/test/smoke.js
+++ b/test/smoke.js
@@ -1,0 +1,182 @@
+/**
+ * test/smoke.js — Smoke test for the Borrow & Die simulator.
+ *
+ * Runs the default-4p scenario and asserts basic sanity invariants.
+ * Exit code 0 = all pass, 1 = any fail.
+ *
+ * Usage:  node test/smoke.js
+ *         npm test
+ */
+
+import { readFileSync }  from 'fs';
+import { fileURLToPath } from 'url';
+import { join, dirname } from 'path';
+import { runScenario }   from '../scenarios/scenario-runner.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// ── Load default-4p config ───────────────────────────────────────────────────
+
+const baseConfig = JSON.parse(
+  readFileSync(join(__dirname, '../scenarios/default-4p.json'), 'utf8'),
+);
+
+// ── Assertion reporter ───────────────────────────────────────────────────────
+
+let passCount = 0;
+let failCount = 0;
+
+function report(name, ok, detail = '') {
+  if (ok) {
+    console.log(`PASS  ${name}`);
+    passCount++;
+  } else {
+    console.log(`FAIL  ${name}${detail ? ' — ' + detail : ''}`);
+    failCount++;
+  }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// PHASE A — 10-game run: assertions 1–5
+// ────────────────────────────────────────────────────────────────────────────
+
+console.log('Running 10 games (assertions 1–4)…');
+
+const negativeCashViolations = [];
+const assetFloorViolations   = [];
+
+const results10 = await runScenario({ ...baseConfig, runs: 10 }, {
+  onYearEnd: async (state) => {
+    // Assertion 5: no catastrophic cash deficit at end of any turn.
+    // The engine does not auto-bankruptcy on negative cash; tax payments are
+    // debited even when the player has insufficient cash (bankruptcy only fires
+    // on collateral violations). Gradual deficits of $1–$3/round are expected
+    // for high-income players with no cash reserves. We flag values below
+    // -(round × 5) as a sign the cash mechanic has broken down catastrophically
+    // (e.g. double-charging taxes, unbounded negative feedback loops).
+    const CASH_FLOOR = -(state.round * 5);
+    for (const player of state.players) {
+      if (player.alive && player.cash < CASH_FLOOR) {
+        negativeCashViolations.push({
+          round:    state.round,
+          playerId: player.id,
+          cash:     player.cash,
+          floor:    CASH_FLOOR,
+        });
+      }
+    }
+
+    // Assertion 4: all asset values >= 1 — scan once per completed game
+    // (state.log is complete when endTriggered because the final bonus year
+    //  runs inside the same runYear() call that set endTriggered)
+    if (state.endTriggered) {
+      for (const ev of state.log) {
+        if (ev.type !== 'ASSET_VALUE_UPDATE') continue;
+        const val = ev.finalValue ?? ev.newValue;
+        if (typeof val === 'number' && val < 1) {
+          assetFloorViolations.push({
+            assetId: ev.assetId,
+            round:   ev.round,
+            value:   val,
+          });
+        }
+      }
+    }
+  },
+});
+
+// Assertion 1: game_length_rounds mean in [4, 20]
+const lengths = results10.map(r => r.metrics.game_length_rounds);
+const mean    = lengths.reduce((a, b) => a + b, 0) / lengths.length;
+report(
+  'game_length_rounds mean is between 4 and 20',
+  mean >= 4 && mean <= 20,
+  `mean=${mean.toFixed(1)}  values=[${lengths.join(', ')}]`,
+);
+
+// Assertion 2: no game ends on round 1 (labor phase always > 0)
+const endedOnRound1 = lengths.filter(l => l === 1);
+report(
+  'no game ends on round 1',
+  endedOnRound1.length === 0,
+  endedOnRound1.length > 0
+    ? `${endedOnRound1.length} game(s) ended on round 1`
+    : '',
+);
+
+// Assertion 3: all asset values >= 1 at all times (floor enforced)
+report(
+  'all asset values >= 1 at all times',
+  assetFloorViolations.length === 0,
+  assetFloorViolations.length > 0
+    ? `first violation: ${JSON.stringify(assetFloorViolations[0])}`
+    : '',
+);
+
+// Assertion 5: no catastrophic cash deficit (floor is -(round × 5))
+report(
+  'no player cash is catastrophically negative (>= -(round × 5))',
+  negativeCashViolations.length === 0,
+  negativeCashViolations.length > 0
+    ? `first violation: ${JSON.stringify(negativeCashViolations[0])}`
+    : '',
+);
+
+// ────────────────────────────────────────────────────────────────────────────
+// PHASE B — 100-game run: assertion 5 (d6 coverage)
+// ────────────────────────────────────────────────────────────────────────────
+
+console.log('Running 100 games (assertion 5: d6 coverage)…');
+
+// Map<assetId, { total: number, seen: Set<number> }>
+const d6Stats = new Map();
+
+await runScenario({ ...baseConfig, runs: 100 }, {
+  onYearEnd: async (state) => {
+    if (!state.endTriggered) return;   // only scan once per completed game
+    for (const ev of state.log) {
+      if (ev.type !== 'ASSET_VALUE_UPDATE') continue;
+      const { assetId, roll } = ev;
+      if (typeof roll !== 'number') continue;
+      if (!d6Stats.has(assetId)) d6Stats.set(assetId, { total: 0, seen: new Set() });
+      const entry = d6Stats.get(assetId);
+      entry.total++;
+      entry.seen.add(roll);
+    }
+  },
+});
+
+// Assertion 5: each asset with >= 30 total rolls must have seen all 6 outcomes.
+// Rarely-bought assets (< 30 rolls) are excluded — statistically normal to miss
+// one face on a fair d6 with very few trials.
+const MIN_ROLLS_FOR_COVERAGE = 30;
+const assetsWithGaps = [];
+for (const [assetId, { total, seen }] of d6Stats) {
+  if (total < MIN_ROLLS_FOR_COVERAGE) continue;
+  const missing = [1, 2, 3, 4, 5, 6].filter(r => !seen.has(r));
+  if (missing.length > 0) {
+    assetsWithGaps.push({ assetId, missing, seen: [...seen].sort(), total });
+  }
+}
+
+report(
+  'd6 coverage — all 6 outcomes rolled per asset across 100 games',
+  assetsWithGaps.length === 0,
+  assetsWithGaps.length > 0
+    ? `${assetsWithGaps.length} asset(s) missing outcomes; first: ` +
+      `${assetsWithGaps[0].assetId} missing [${assetsWithGaps[0].missing}] ` +
+      `seen [${assetsWithGaps[0].seen}]`
+    : '',
+);
+
+// ────────────────────────────────────────────────────────────────────────────
+// Summary
+// ────────────────────────────────────────────────────────────────────────────
+
+const total = passCount + failCount;
+console.log(
+  `\n${total} assertion${total !== 1 ? 's' : ''}: ` +
+  `${passCount} passed, ${failCount} failed`,
+);
+
+if (failCount > 0) process.exit(1);


### PR DESCRIPTION
## Summary

This PR significantly streamlines the project documentation and adds a comprehensive smoke test suite to validate core game engine invariants.

## Key Changes

**Documentation (README.md)**
- Replaced 312-line design document with a 215-line quick-start guide focused on simulator usage
- Removed extensive game design sections (mechanics, card inventory, turn sequence, CEO abilities) — these are now reference material outside the repo
- Added practical CLI examples, scenario configuration guide, and agent implementation instructions
- Documented all tracked metrics (Tier A–C) with health targets and red flags for design validation
- Added "Known limitations" section flagging approximations (CEO abilities, negative cash handling, GMI buy/sell pressure)
- Restructured project layout documentation for clarity

**Test Suite (test/smoke.js)**
- Added 5 core assertions across 110 total game runs:
  1. `game_length_rounds` mean is between 4–20 rounds
  2. No game ends on round 1 (labor phase validation)
  3. All asset values remain ≥ 1 (floor enforcement)
  4. No player cash falls below `-(round × 5)` (catastrophic deficit detection)
  5. d6 coverage — all 6 dice outcomes rolled per asset across 100 games (RNG validation)
- Runs 10 games for assertions 1–4, then 100 games for d6 statistical coverage
- Hooks into `onYearEnd` callback to inspect game state and event logs
- Provides detailed failure reporting with violation examples
- Exit code 0 on pass, 1 on fail

**Package.json**
- Updated `npm test` script to run `node test/smoke.js` instead of placeholder error

## Implementation Details

- Smoke test uses the existing `runScenario()` infrastructure with custom callbacks to avoid re-running games
- Assertions focus on game health (length, progression) and engine correctness (asset floors, cash bounds, RNG distribution)
- d6 coverage assertion only flags assets with ≥30 rolls to avoid false positives on rarely-purchased cards
- Test is deterministic (uses seeded RNG from scenario config) and completes in ~30 seconds

https://claude.ai/code/session_01CHVGBBWvA22M2cedq24t6v