### PR TITLE
Add HTTP server for dashboard with run file listing

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -386,6 +386,9 @@ body {
     <p>Drag &amp; drop a <code>*.json</code> run file here,<br>or click to browse</p>
     <button id="file-btn">Choose File</button>
     <input type="file" id="file-input" accept=".json,application/json">
+    <select id="run-select" style="display:none;margin-top:12px;background:#1a1a3e;color:#e0e0e0;border:1px solid #2a2a5e;padding:6px 10px;border-radius:6px;font-size:0.9rem;">
+      <option value="">— or pick a run from server —</option>
+    </select>
   </div>
   <div id="drop-error"></div>
 </div>
@@ -1666,6 +1669,30 @@ function readFile(file) {
   reader.onload = ev => loadRuns(ev.target.result, file.name);
   reader.onerror = () => setDropError('Failed to read file.');
   reader.readAsText(file);
+}
+
+// ── Server-side run picker (only active when served via HTTP) ────────────
+if (location.protocol !== 'file:') {
+  fetch('/runs/')
+    .then(r => r.json())
+    .then(({ files }) => {
+      if (!files.length) return;
+      const sel = document.getElementById('run-select');
+      files.forEach(f => {
+        const opt = document.createElement('option');
+        opt.value = f;
+        opt.textContent = f;
+        sel.appendChild(opt);
+      });
+      sel.style.display = '';
+      sel.addEventListener('change', async () => {
+        if (!sel.value) return;
+        const res  = await fetch(`/runs/${encodeURIComponent(sel.value)}`);
+        const text = await res.text();
+        loadRuns(text, sel.value);
+      });
+    })
+    .catch(() => {});
 }
 
 // ── Reload button ──────────────────────────────────────────────────────────

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -1,0 +1,67 @@
+import http from 'http';
+import fs   from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname  = path.dirname(fileURLToPath(import.meta.url));
+const PORT       = Number(process.env.PORT) || 3000;
+
+const DASHBOARD_ROOT = __dirname;
+const RUNS_ROOT      = path.resolve(__dirname, '../output/runs');
+
+const MIME = {
+  '.html': 'text/html; charset=utf-8',
+  '.js':   'application/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.css':  'text/css; charset=utf-8',
+  '.ico':  'image/x-icon',
+};
+
+function send(res, status, contentType, body) {
+  res.writeHead(status, { 'Content-Type': contentType });
+  res.end(body);
+}
+
+function serveFile(res, filePath) {
+  const ext  = path.extname(filePath).toLowerCase();
+  const mime = MIME[ext] || 'application/octet-stream';
+  fs.readFile(filePath, (err, data) => {
+    if (err) { send(res, 404, 'text/plain', 'Not found'); return; }
+    send(res, 200, mime, data);
+  });
+}
+
+const server = http.createServer((req, res) => {
+  const urlPath = new URL(req.url, `http://localhost:${PORT}`).pathname;
+
+  // /runs/ → JSON listing of available simulation output files
+  if (urlPath === '/runs' || urlPath === '/runs/') {
+    fs.readdir(RUNS_ROOT, (err, files) => {
+      const jsonFiles = err ? [] : files.filter(f => f.endsWith('.json')).sort();
+      send(res, 200, MIME['.json'], JSON.stringify({ files: jsonFiles }));
+    });
+    return;
+  }
+
+  // /runs/<file> → serve individual run file
+  if (urlPath.startsWith('/runs/')) {
+    const filename = path.basename(urlPath); // prevents path traversal
+    serveFile(res, path.join(RUNS_ROOT, filename));
+    return;
+  }
+
+  // dashboard/ static files
+  const relPath  = urlPath === '/' ? '/index.html' : urlPath;
+  const filePath = path.resolve(DASHBOARD_ROOT, '.' + relPath);
+  if (!filePath.startsWith(DASHBOARD_ROOT)) {
+    send(res, 403, 'text/plain', 'Forbidden');
+    return;
+  }
+  serveFile(res, filePath);
+});
+
+server.listen(PORT, () => {
+  console.log(`Dashboard →  http://localhost:${PORT}`);
+  console.log(`Runs list →  http://localhost:${PORT}/runs/`);
+  console.log('Ctrl+C to stop.');
+});

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "test": "node test/smoke.js"
+    "test":    "node test/smoke.js",
+    "preview": "node dashboard/server.js"
   },
   "dependencies": {
     "chart.js": "^4.4.0",


### PR DESCRIPTION
## Summary
This PR adds a lightweight HTTP server for the dashboard that enables browsing and loading simulation run files directly from the server, improving the user experience when running the dashboard locally.

## Key Changes
- **New `dashboard/server.js`**: Implements a simple Node.js HTTP server that:
  - Serves static dashboard files (HTML, CSS, JS) from the dashboard directory
  - Provides a `/runs/` endpoint that lists available JSON run files from `output/runs/`
  - Serves individual run files via `/runs/<filename>` with proper MIME type handling
  - Includes path traversal protection for security
  
- **Enhanced `dashboard/index.html`**: 
  - Added a dropdown selector (`#run-select`) to the file upload section
  - Integrated client-side logic to fetch and populate the dropdown with available runs from the server
  - Allows users to select and load runs directly from the dropdown instead of manual file browsing
  - Gracefully degrades when accessed via `file://` protocol (dropdown hidden)

- **Updated `package.json`**: 
  - Added `preview` npm script to easily start the dashboard server with `npm run preview`

## Implementation Details
- The server uses Node.js built-in `http` module with no external dependencies
- MIME type mapping covers common web assets (HTML, JS, JSON, CSS, ICO)
- The run picker only activates when the dashboard is served over HTTP (not `file://` protocol)
- Dropdown population is non-blocking with error handling via `.catch()`
- File serving includes proper error handling (404 for missing files, 403 for path traversal attempts)

https://claude.ai/code/session_01HhKnLrCSbViPsDh8X6txCs