### PR TITLE
Refactor event display to use centralized notable events collection

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -324,10 +324,12 @@ body {
   font-size: 0.7rem;
   margin-right: 6px;
 }
-.event-tag.death  { color: #ff1744; }
-.event-tag.bonus  { color: #ffd740; }
-.event-tag.asset  { color: #a5d6a7; }
-.event-tag.gmi    { color: #ce93d8; }
+.event-tag.death   { color: #ff1744; }
+.event-tag.bonus   { color: #ffd740; }
+.event-tag.asset   { color: #a5d6a7; }
+.event-tag.gmi     { color: #ce93d8; }
+.event-tag.market  { color: #ce93d8; }
+.event-tag.event   { color: #80deea; }
 
 /* ── Data table ────────────────────────────────────────────────────────────── */
 .data-table {
@@ -582,6 +584,7 @@ body {
       <div class="chart-wrap" style="margin-bottom:20px">
         <div class="chart-title">Asset Values This Round</div>
         <div class="chart-inner" style="height:220px">
+          <p id="replay-assets-empty" class="muted" style="display:none;padding:16px 0;text-align:center">No assets held this round</p>
           <canvas id="chart-replay-assets"></canvas>
         </div>
       </div>
@@ -1442,27 +1445,7 @@ function renderReplayRound() {
   // ── Events ────────────────────────────────────────────────────────────────
   const evList = document.getElementById('replay-event-list');
   evList.innerHTML = '';
-  const events = [];
-
-  // Integration bonuses this round
-  for (const b of (m.integration_bonuses_fired || [])) {
-    if (b.round === round) {
-      events.push({
-        tag: 'BONUS', tagClass: 'bonus',
-        text: `${b.playerId}: ${b.bonusType}`,
-      });
-    }
-  }
-
-  // Death roll (if this is the first death round)
-  if (m.first_death_roll_round === round) {
-    for (const dr of (m.stress_at_death_roll || [])) {
-      events.push({
-        tag: 'DEATH ROLL', tagClass: 'death',
-        text: `${dr.playerId} — stress ${dr.stressLevel}`,
-      });
-    }
-  }
+  const events = (m.notable_events_by_round ?? {})[round] ?? [];
 
   if (!events.length) {
     const li = document.createElement('li');
@@ -1480,6 +1463,9 @@ function renderReplayRound() {
   const activeAssets = (m.asset_value_trajectories || [])
     .map(t => ({ id: t.assetId, industry: t.industry, val: (t.valueByRound || [])[round - 1] }))
     .filter(a => a.val != null);
+
+  const assetsEmptyEl = document.getElementById('replay-assets-empty');
+  if (assetsEmptyEl) assetsEmptyEl.style.display = activeAssets.length === 0 ? 'block' : 'none';
 
   makeChart('chart-replay-assets', {
     type: 'bar',

--- a/metrics/collector.js
+++ b/metrics/collector.js
@@ -157,6 +157,14 @@ export function collect(state) {
   // playerId → t3 purchase count
   const t3ByPlayer = {};
 
+  // per-round notable events for replay display
+  // { [round]: Array<{ tag, tagClass, text }> }
+  const notableEventsByRound = {};
+  const addNotable = (r, tag, tagClass, text) => {
+    if (!notableEventsByRound[r]) notableEventsByRound[r] = [];
+    notableEventsByRound[r].push({ tag, tagClass, text });
+  };
+
   // ── Single-pass log scan ──────────────────────────────────────────────────
 
   for (const ev of log) {
@@ -177,7 +185,8 @@ export function collect(state) {
       case 'DEATH_ROLL': {
         if (first_death_roll_round === null) first_death_roll_round = round;
         if (!ev.survived) death_count++;
-        stressAtDeathRolls.push({ playerId: ev.playerId, stressLevel: ev.stress });
+        stressAtDeathRolls.push({ playerId: ev.playerId, stressLevel: ev.stress, round });
+        addNotable(round, 'DEATH ROLL', 'death', `${ev.playerId} — stress ${ev.stress}`);
         break;
       }
 
@@ -204,8 +213,13 @@ export function collect(state) {
       }
 
       case 'GMI_UPDATE': {
-        // Keep the last update seen for this round (Lobbyist may adjust after)
-        gmiByRound[round] = ev.newGmi;
+        // Keep the last update seen for this round (Lobbyist may adjust after).
+        // Store the per-round delta (not the cumulative newGmi) so the replay
+        // dashboard can display "GMI Delta this round" correctly.
+        gmiByRound[round] = ev.gmiDelta;
+        const sign = ev.gmiDelta > 0 ? '+' : '';
+        addNotable(round, 'MARKET', 'market',
+          `${ev.eventName}: GMI ${sign}${ev.gmiDelta}`);
         break;
       }
 
@@ -235,6 +249,7 @@ export function collect(state) {
       case 'PERSONAL_EVENT_APPLIED': {
         // IMMEDIATE cards resolve straight away → action PLAY
         personalEventActions.push({ cardName: ev.eventName, action: 'PLAY' });
+        addNotable(round, 'EVENT', 'event', `${ev.playerId}: ${ev.eventName}`);
         break;
       }
 
@@ -255,6 +270,7 @@ export function collect(state) {
           bonusType: ev.effectType,
           round,
         });
+        addNotable(round, 'BONUS', 'bonus', `${ev.playerId}: ${ev.effectType}`);
         break;
       }
 
@@ -352,5 +368,6 @@ export function collect(state) {
     t3_acquisitions,
     income_vs_score,
     has_vertical_stack,
+    notable_events_by_round:   notableEventsByRound,
   };
 }


### PR DESCRIPTION
## Summary
Refactored the event collection and display system to centralize notable events in the metrics collector rather than computing them on-demand in the dashboard. This improves maintainability and enables consistent event tracking across the replay interface.

## Key Changes

- **Centralized event collection**: Moved event aggregation logic from dashboard HTML to `metrics/collector.js`, creating a `notableEventsByRound` structure that tracks all notable events per round
- **New event types**: Added support for `MARKET` (GMI updates) and `EVENT` (personal events) tags with appropriate styling
- **GMI tracking fix**: Changed `gmiByRound` to store per-round delta instead of cumulative `newGmi`, enabling correct "GMI Delta this round" display in the replay dashboard
- **Enhanced death roll tracking**: Added `round` field to death roll stress data for better event correlation
- **Empty state handling**: Added UI element to display "No assets held this round" message when the asset chart has no data
- **CSS alignment**: Normalized spacing in event tag class definitions and added color definitions for new event types (`#ce93d8` for market, `#80deea` for event)

## Implementation Details

The `addNotable()` helper function standardizes event creation with consistent `{ tag, tagClass, text }` structure. Events are now collected during the single-pass log scan in the collector, eliminating duplicate logic and ensuring all event types are captured uniformly. The dashboard simply retrieves pre-computed events from `m.notable_events_by_round[round]` rather than reconstructing them.

https://claude.ai/code/session_01R14LxwTr4AmEMUgFPAeKdh