### PR TITLE
Add mitigation rolls to stress penalties for CEO abilities

### DIFF
--- a/data/cards/ceo-cards.json
+++ b/data/cards/ceo-cards.json
@@ -147,7 +147,7 @@
       {
         "abilityType": "RISK",
         "frequency": "ON_TRIGGER",
-        "description": "If the rerolled result is strictly lower than the original roll, gain +1 stress immediately. The house always wins eventually.",
+        "description": "If the rerolled result is strictly lower than the original roll, roll a d6. On a 1, gain +1 stress immediately. The house always wins eventually.",
         "stressEffect": 1
       }
     ],
@@ -210,7 +210,7 @@
       {
         "abilityType": "RISK",
         "frequency": "ON_TRIGGER",
-        "description": "At the end of any year in which your total asset value did not increase compared to the start of that year, gain +1 stress. Stagnation is existential.",
+        "description": "At the end of any year in which your total asset value did not increase compared to the start of that year, roll a d6. On a 1, gain +1 stress. Stagnation is existential.",
         "stressEffect": 1
       }
     ],

--- a/engine/ceo.js
+++ b/engine/ceo.js
@@ -153,14 +153,19 @@ export function applyCEOAbilities(player, phase, state, dice, context = {}) {
       }
     }
 
-    // Visionary RISK: if asset value did not increase, +1 stress
+    // Visionary RISK: if asset value did not increase, roll d6 — stress only on a 1
     if (ceoName === 'The Visionary' && context.assetValueIncreased === false) {
-      player.stress += 1;
+      const roll = dice.d6();
+      const stressGained = roll === 1 ? 1 : 0;
+      if (stressGained > 0) {
+        player.stress += stressGained;
+      }
       logEvents.push({
         type:      'CEO_ABILITY',
         ceoName,
         ability:   'VISIONARY_STAGNATION_STRESS',
-        delta:     1,
+        roll,
+        delta:     stressGained,
         newStress: player.stress,
       });
     }
@@ -234,21 +239,24 @@ export function useGamblerReroll(player, originalRoll, dice) {
 
   as.gamblerRerollUsedThisYear = true;
 
-  const newRoll     = dice.d6();
-  const stressGained = newRoll < originalRoll ? 1 : 0;
+  const newRoll        = dice.d6();
+  const lowerRoll      = newRoll < originalRoll;
+  const mitigationRoll = lowerRoll ? dice.d6() : 0;
+  const stressGained   = (lowerRoll && mitigationRoll === 1) ? 1 : 0;
 
   if (stressGained > 0) {
     player.stress += stressGained;
   }
 
   const logEvent = {
-    type:         'CEO_ABILITY',
-    ceoName:      'The Gambler',
-    ability:      'GAMBLER_REROLL',
-    oldRoll:      originalRoll,
+    type:           'CEO_ABILITY',
+    ceoName:        'The Gambler',
+    ability:        'GAMBLER_REROLL',
+    oldRoll:        originalRoll,
     newRoll,
+    mitigationRoll: lowerRoll ? mitigationRoll : null,
     stressGained,
-    newStress:    player.stress,
+    newStress:      player.stress,
   };
 
   return { newRoll, oldRoll: originalRoll, stressGained, logEvent };

--- a/engine/turn.js
+++ b/engine/turn.js
@@ -495,16 +495,22 @@ function runSettlementPhase(state, agentMap, dice) {
     appendLog(state, [cvLog]);
 
     if (violated) {
-      // Force loans down to current capacity; excess triggers +1 stress.
-      const excess     = totalLoans - totalCapacity;
-      player.loans     = totalCapacity;
-      player.stress   += 1;
+      // Force loans down to current capacity; excess triggers stress roll (stress on a 1).
+      const excess         = totalLoans - totalCapacity;
+      player.loans         = totalCapacity;
+      const mitigationRoll = dice.d6();
+      const stressGained   = mitigationRoll === 1 ? 1 : 0;
+      if (stressGained > 0) {
+        player.stress += stressGained;
+      }
       appendLog(state, [{
-        type:        'COLLATERAL_FORCED_REDUCTION',
-        playerId:    player.id,
-        excessLoans: excess,
-        newLoans:    player.loans,
-        newStress:   player.stress,
+        type:            'COLLATERAL_FORCED_REDUCTION',
+        playerId:        player.id,
+        excessLoans:     excess,
+        newLoans:        player.loans,
+        mitigationRoll,
+        stressGained,
+        newStress:       player.stress,
       }]);
     }
 


### PR DESCRIPTION
## Summary
This PR introduces mitigation rolls for stress penalties across three CEO-related mechanics. Instead of automatically gaining stress, players now roll a d6 and only gain stress on a roll of 1, reducing the guaranteed penalty while maintaining risk.

## Key Changes
- **The Visionary CEO ability**: Changed from automatic +1 stress when asset value doesn't increase to a d6 roll where stress is only gained on a 1
- **The Gambler reroll ability**: Added a mitigation roll when the reroll result is lower than the original—stress is only gained if both conditions are met (lower roll AND mitigation roll of 1)
- **Collateral forced reduction**: Changed from automatic +1 stress when loans exceed capacity to a d6 roll where stress is only gained on a 1
- **Card descriptions**: Updated CEO card text to reflect the new d6 mitigation mechanics
- **Logging**: Enhanced event logs to include the mitigation roll results for better game state tracking

## Implementation Details
- All three mechanics follow the same pattern: roll d6, gain stress only on a 1
- Stress is only applied if `stressGained > 0`, maintaining consistent conditional logic
- Log events now include `mitigationRoll` and `stressGained` fields for transparency
- The Gambler's mitigation roll is only performed when the new roll is actually lower than the original (optimization to avoid unnecessary rolls)

https://claude.ai/code/session_01Mv2rExC2WC3U5p5MATwKVT