### PR TITLE
Add starter asset income to tax and settlement calculations

### DIFF
--- a/engine/taxes.js
+++ b/engine/taxes.js
@@ -20,12 +20,13 @@
  * @returns {{ grossIncome: number, loanOffset: number, netTaxable: number, taxDue: number }}
  */
 export function computeTaxableIncome(player, loansDrawnThisYear = 0) {
-  const assetIncome = (player.assets ?? []).reduce(
+  const assetIncome   = (player.assets ?? []).reduce(
     (sum, asset) => sum + (asset.income ?? 0),
     0,
   );
-  const ceoIncome  = player.ceo?.annualIncome ?? 0;
-  const grossIncome = assetIncome + ceoIncome;
+  const starterIncome = player.starterAsset?.income ?? 0;
+  const ceoIncome     = player.ceo?.annualIncome ?? 0;
+  const grossIncome   = assetIncome + starterIncome + ceoIncome;
 
   // loanOffset can only reduce the portion above the first free $1
   const loanOffset  = Math.min(Math.max(0, grossIncome - 1), Math.max(0, loansDrawnThisYear));
@@ -46,6 +47,7 @@ export function computeTaxableIncome(player, loansDrawnThisYear = 0) {
  * @returns {{ logEvent: object }}
  */
 export function applyTax(player, taxDue, { loanOffset = 0, grossIncome = 0 } = {}) {
+  player.cash      += grossIncome;
   player.cash      -= taxDue;
   player.taxesPaid += taxDue;
 

--- a/engine/turn.js
+++ b/engine/turn.js
@@ -234,8 +234,9 @@ function runAuctionPhase(state, agentMap, dice) {
       }
 
       if (winner) {
-        winner.cash -= winningBid;
-        winner.ceo   = card;
+        winner.cash         -= winningBid;
+        winner.ceo           = card;
+        winner.starterAsset  = card.starterAsset ?? null;
         // Apply CEO starting stress
         winner.stress = Math.max(winner.stress, card.startingStress ?? 0);
         appendLog(state, [{
@@ -423,9 +424,10 @@ function runSettlementPhase(state, agentMap, dice) {
 
     if (isTaxAttorney) {
       // Tax Attorney: first $2 of income is always tax-free (instead of $1)
-      const assetIncome = (player.assets ?? []).reduce((s, a) => s + (a.income ?? 0), 0);
-      const ceoIncome   = player.ceo?.annualIncome ?? 0;
-      grossIncome       = assetIncome + ceoIncome;
+      const assetIncome   = (player.assets ?? []).reduce((s, a) => s + (a.income ?? 0), 0);
+      const starterIncome = player.starterAsset?.income ?? 0;
+      const ceoIncome     = player.ceo?.annualIncome ?? 0;
+      grossIncome         = assetIncome + starterIncome + ceoIncome;
       loanOffset        = Math.min(
         Math.max(0, grossIncome - 2),
         Math.max(0, loansDrawnThisYear),
@@ -441,6 +443,7 @@ function runSettlementPhase(state, agentMap, dice) {
       const { logEvent } = applyTax(player, taxDue, { loanOffset, grossIncome });
       appendLog(state, [logEvent]);
     } else {
+      player.cash += grossIncome;
       appendLog(state, [{
         type:       'TAX_APPLIED',
         playerId:   player.id,


### PR DESCRIPTION
## Summary
This PR adds support for starter assets as an income source in tax calculations and settlement phases. When a CEO card with a starter asset is acquired, the starter asset's income is now properly tracked and included in gross income computations.

## Key Changes
- **Auction Phase**: Store the starter asset from CEO cards on the player object (`player.starterAsset`) when a CEO is won
- **Tax Calculations**: Include starter asset income in `computeTaxableIncome()` alongside asset and CEO income
- **Settlement Phase**: 
  - Include starter asset income when calculating gross income for tax purposes
  - Apply gross income to player cash before deducting taxes in both Tax Attorney and standard paths
- **Code Formatting**: Aligned variable declarations for improved readability across modified functions

## Implementation Details
- Starter asset is extracted from the CEO card using optional chaining (`card.starterAsset ?? null`)
- Starter asset income is treated consistently with other income sources in tax calculations
- The gross income is now applied to player cash in `applyTax()` rather than only in the non-Tax Attorney settlement path, ensuring consistent cash flow handling

https://claude.ai/code/session_01HgihZexPVRLfSe2Jih2bAx