### PR TITLE
Fix replay listener attachment and game length calculation

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1400,9 +1400,10 @@ function renderStress(agg) {
 // TAB 5: REPLAY
 // ════════════════════════════════════════════════════════════════════════════
 
-let _replayRuns   = [];
-let _replayRunIdx = 0;
-let _replayRound  = 1;
+let _replayRuns              = [];
+let _replayRunIdx            = 0;
+let _replayRound             = 1;
+let _replayListenersAttached = false;
 
 function populateRunSelect(runs) {
   const sel = document.getElementById('replay-run-select');
@@ -1532,6 +1533,9 @@ function initReplay(runs) {
   _replayRuns = runs;
   populateRunSelect(runs);
   switchReplayRun(0);
+
+  if (_replayListenersAttached) return;
+  _replayListenersAttached = true;
 
   document.getElementById('replay-run-select').addEventListener('change', e => {
     switchReplayRun(+e.target.value);

--- a/metrics/collector.js
+++ b/metrics/collector.js
@@ -131,7 +131,6 @@ export function collect(state) {
 
   let first_asset_round        = null;
   let first_death_roll_round   = null;
-  let game_length_rounds       = 0;
   let death_count              = 0;
   let bankruptcy_count         = 0;
   let collateral_violation_count = 0;
@@ -201,9 +200,6 @@ export function collect(state) {
       }
 
       case 'END_TRIGGER': {
-        // Record the round in which endTriggered was first set.
-        // Only take the first one (in case multiple players die somehow).
-        if (!game_length_rounds) game_length_rounds = round;
         break;
       }
 
@@ -279,9 +275,9 @@ export function collect(state) {
     }
   }
 
-  // ── Fallback for game_length_rounds ───────────────────────────────────────
-  // If END_TRIGGER never fired (shouldn't happen in normal play) use state.round.
-  if (!game_length_rounds) game_length_rounds = state.round ?? 0;
+  // ── game_length_rounds: use state.round, which reflects the true last round
+  // played (including the post-death final round run after END_TRIGGER fires).
+  const game_length_rounds = state.round ?? 0;
 
   // ── gmi_by_round: dense integer array, one entry per round (1-indexed) ────
   const gmi_by_round = [];


### PR DESCRIPTION
## Summary
This PR fixes two issues: preventing duplicate event listener attachment in the replay tab and correcting the game length calculation to use the actual final round from game state.

## Key Changes

**Dashboard Replay Tab (index.html):**
- Added `_replayListenersAttached` flag to track whether event listeners have been attached to the replay controls
- Added guard clause in `initReplay()` to prevent attaching duplicate event listeners on subsequent calls
- Aligned variable declarations for better code formatting

**Metrics Collector (collector.js):**
- Removed the `game_length_rounds` variable initialization and manual tracking via `END_TRIGGER` event
- Changed `game_length_rounds` to be directly assigned from `state.round` instead of being conditionally set
- Updated the logic to use the true final round from game state, which includes the post-death final round that occurs after `END_TRIGGER` fires

## Implementation Details

The replay listener fix prevents potential issues where event handlers could be registered multiple times if `initReplay()` is called more than once, which could cause duplicate event handling.

The game length calculation change simplifies the logic by relying on `state.round` as the source of truth for the final round played, rather than trying to capture it from the `END_TRIGGER` event. This ensures the metric accurately reflects the complete game duration including any final round execution after the end trigger.

https://claude.ai/code/session_01YWrZhhuUuuAhEhcR4oj8Do